### PR TITLE
Handled name conflicts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ If the base output path (GAME\_RIP\_ROM\_BASE\_PATH) has a matching subdirectory
 
 The ownership of the output ROM file will be matched to that of the directory it's in.
 
+If a ROM file already exists with the same name, it will be renamed to end with a ".old" suffix.
+
 ## Configuration and Defaults
 **The script assumes your CD drive is /dev/sr0 and that the desired directory for finished ROM files is ~/Games/.** There are 3 ways to override one or both of these:
 1. Edit the first few lines of game\_rip.sh. Note that these changes will be reverted if you perform a git pull to update your local copy of the script.

--- a/image/app/rip.sh
+++ b/image/app/rip.sh
@@ -24,6 +24,15 @@ set_dest_path() {
 	DEST_PATH=${POTENTIAL_PATH:-$DEST_PATH}
 }
 
+# If the output file already exists, rename it.
+# The first and only argument should be the file suffix (no ".").
+rename_existing() {
+	if [ -f "$DEST_PATH/$ROM_NAME.$1" ]; then
+		echo "$ROM_NAME.$1 exists; renaming it to $ROM_NAME.$1.old"
+		mv "$DEST_PATH/$ROM_NAME.$1" "$DEST_PATH/$ROM_NAME.$1.old"
+	fi
+}
+
 # Basic argument check.
 if [ $# -eq 2 ]; then
 	CONSOLE=$1
@@ -38,10 +47,12 @@ fi
 case "$CONSOLE" in
 	psx|ps1)
 		set_dest_path 'ps[x1]?|playstation( ?[x1])?'
+		rename_existing 'chd'
 		time ./rip_psx.sh
 		;;
 	ps2)
 		set_dest_path 'ps2|playstation( ?2)?'
+		rename_existing 'chd'
 		time ./rip_ps2.sh
 		;;
 	*)


### PR DESCRIPTION
If an existing ROM has the same filename, it'll be renamed to "ROM_NAME.(suffix).old".