### PR TITLE
Took ramdisk/tmpfs space into consideration.

### DIFF
--- a/image/app/rip_with_cdrdao.sh
+++ b/image/app/rip_with_cdrdao.sh
@@ -5,9 +5,7 @@
 set -e
 
 # Work in the ramdisk folder.
-cd /tmp/ramdisk
-mkdir -p working output
-cd working
+cd "$WORKING_PATH"
 
 # Rip the disk contents into a .toc and .bin file.
 cdrdao read-cd --read-raw \
@@ -25,7 +23,4 @@ toc2cue -sC rom.bin \
 # as determined by the environment variables.
 chdman createcd \
 	-i rom.cue \
-	-o "../output/$ROM_NAME.chd"
-
-# Change to the output directory for the parent script.
-cd ../output
+	-o "$STAGE_PATH/$ROM_NAME.chd"

--- a/image/app/rip_with_dd.sh
+++ b/image/app/rip_with_dd.sh
@@ -5,9 +5,7 @@
 set -e
 
 # Work in the ramdisk folder.
-cd /tmp/ramdisk
-mkdir -p working output
-cd working
+cd "$WORKING_PATH"
 
 # Rip the disk contents into a .iso file.
 echo "Ripping with dd; you may not see any output for a while."
@@ -17,7 +15,4 @@ dd if=/dev/cdrom of=rom.iso
 # the environment variables.
 chdman createcd \
 	-i rom.iso \
-	-o "../output/$ROM_NAME.chd"
-
-# Change to the output directory for the parent script.
-cd ../output
+	-o "$STAGE_PATH/$ROM_NAME.chd"


### PR DESCRIPTION
Now, the ramdisk is used if its capacity is at least 125% of the disk's; otherwise /tmp is used within the docker container.